### PR TITLE
Validation & error handling

### DIFF
--- a/routes/image.mjs
+++ b/routes/image.mjs
@@ -1,0 +1,91 @@
+import express from "express";
+import bodyParser from "body-parser";
+import { getStorage, ref, uploadBytes } from "firebase/storage";
+import { ImageAnnotatorClient } from "@google-cloud/vision";
+import { collection, addDoc } from "firebase/firestore"; 
+
+import { fileURLToPath } from "url";
+import path from "path";
+
+// Get the current module's file path
+const __filename = fileURLToPath(import.meta.url);
+
+// Get the current module's directory path
+const __dirname = path.dirname(__filename);
+
+console.log(__dirname);
+
+const client = new ImageAnnotatorClient({
+  keyFilename: __dirname + "/../config/tgin13-22678df230b0.json",
+});
+
+const router = express.Router();
+
+router.use(bodyParser.raw({ type: "application/octet-stream", limit: "10mb" }));
+
+// Get image data
+router.get("/:id", (req, res) => {});
+
+// Upload image
+// Find out how IMAGE can be sent from Mower to API?
+router.post("/upload/:mowerID", async (req, res) => {
+  // 1. Upload to Firebase Storage
+  const dummyUserID = req.params.mowerID;
+  const date = "2022-03-30_13:35:24";
+  const storage = getStorage();
+
+  const uint8Array = new Uint8Array(req.body);
+
+  const newImageReference = ref(storage, `${dummyUserID}/${date}.jpg`);
+
+  try {
+    const uploadResult = await uploadBytes(newImageReference, uint8Array)
+    console.log(`Uploaded Image!`);
+
+    // 2. Perform Image Classification using Google API
+
+    const features = [
+      {
+        type: "OBJECT_LOCALIZATION",
+        maxResults: 1,
+      },
+    ];
+
+    const request = {
+      image: {
+        content: Buffer.from(uint8Array).toString("base64"),
+      },
+      features: features,
+    };
+
+    const results = await client.annotateImage(request)
+    console.log(results[0].localizedObjectAnnotations[0].name);
+
+    // 3. Add item to Firestore, connecting both image and annotations.
+    try {
+      console.log(req.db);
+      await addDoc(collection(req.db, "avoidedCollisions"), {
+        object: results[0].localizedObjectAnnotations[0].name,
+        objectDetectionAccuracy : results[0].localizedObjectAnnotations[0].score, 
+        imageLink: uploadResult.metadata.fullPath,
+        date: Date.now()
+      })
+
+      console.log(`uploaded doc!`);
+
+    } catch(e) {
+      console.log(`ERROR OCCUREED`);
+      console.log(e);
+    }
+
+
+    console.log(`FINISHED, STATUS : 200`);
+
+    res.sendStatus(200);
+
+  } catch {
+    res.sendStatus(500);
+  }
+});
+
+export default router;

--- a/routes/position.mjs
+++ b/routes/position.mjs
@@ -1,0 +1,22 @@
+import express from "express"
+const router = express.Router();
+
+// What is the data format for position? 
+
+// Get current position for 
+router.get("/", (req, res) => {
+    console.log(`Someone tried to GET position`);
+    const coordinates = {
+        x: 100,
+        y: 204
+    }
+    res.json(coordinates)
+})
+
+// Update position
+router.post("/update", (req, res) => {
+    // 1. Store previous position in MowSession.path
+    // 2. Replace Mower.position with new position.
+})
+
+export default router

--- a/src/businessLogic/imageService.mjs
+++ b/src/businessLogic/imageService.mjs
@@ -1,4 +1,4 @@
-import { ValidationError, InternalServerError } from '../utils/errors.mjs';
+import { ValidationError } from '../utils/errors.mjs';
 
 export default class ImageService {
     constructor({ imageRepository }) {

--- a/src/businessLogic/imageService.mjs
+++ b/src/businessLogic/imageService.mjs
@@ -1,3 +1,5 @@
+import { ValidationError, InternalServerError } from '../utils/errors.mjs';
+
 export default class ImageService {
     constructor({ imageRepository }) {
         this.imageRepository = imageRepository;

--- a/src/businessLogic/imageService.mjs
+++ b/src/businessLogic/imageService.mjs
@@ -2,68 +2,52 @@ import { ValidationError } from '../utils/errors.mjs';
 import { formatDate } from '../utils/dateFormatter.mjs';
 
 export default class ImageService {
-    constructor({ imageRepository }) {
+    constructor({ imageRepository, mowSessionRepository }) {
         this.imageRepository = imageRepository;
+        this.mowSessionRepository = mowSessionRepository
+
     }
 
-    uploadImageToStorage(mowerID, imageUInt8Array) {
-        return new Promise(async (resolve, reject) => {
-            const currentDate = new Date();
-            const formattedDateTime = formatDate(currentDate)
-            const imageFilename = `${mowerID}/${formattedDateTime}.jpg`;
-            try {
-                const fileName =
-                    await this.imageRepository.uploadImageToStorage(
-                        imageFilename,
-                        imageUInt8Array
-                    );
-                resolve(fileName);
-            } catch (e) {
-                reject(e);
-            }
-        });
+    async mowerExists(mowerId){
+        const mower = await this.mowerRepository.getMowerById(mowerId)
+        return mower == null ? false : true
     }
 
-    classifyImage(imageUInt8Array) {
-        return new Promise(async (resolve, reject) => {
-            const features = [
-                {
-                    type: "OBJECT_LOCALIZATION",
-                    maxResults: 1,
-                },
-            ];
+    async uploadImageToStorage(mowerID, imageUInt8Array) {
+        const currentDate = new Date();
+        const formattedDateTime = formatDate(currentDate);
+        const imageFilename = `${mowerID}/${formattedDateTime}.jpg`;
 
-            const request = {
-                image: {
-                    content: Buffer.from(imageUInt8Array).toString("base64"),
-                },
-                features: features,
-            };
+        const mowerExists = await this.mowerExists(mowerID)
+        if(mowerExists){
+            const fileName = await this.imageRepository.uploadImageToStorage(imageFilename, imageUInt8Array);
+            return fileName;
+        } else {
+            throw new ValidationError("The mower does not exist")
+        }
+    }
 
-            try {
-                const annotationResults =
-                    this.imageRepository.classifyImage(request);
-                resolve(annotationResults);
-            } catch (e) {
-                reject(e);
-            }
-        });
+    async classifyImage(imageUInt8Array) {
+        const features = [
+            {
+                type: "OBJECT_LOCALIZATION",
+                maxResults: 1,
+            },
+        ];
+    
+        const request = {
+            image: {
+                content: Buffer.from(imageUInt8Array).toString("base64"),
+            },
+            features: features,
+        };
+    
+
+        const annotationResults = await this.imageRepository.classifyImage(request);
+        return annotationResults;
     }
 
     async uploadAvoidedCollisionData(mowerID, mowSessionID, avoidedCollisionData) {
-        return new Promise(async (resolve, reject) => {
-            // Validation for avoidedCollisionData object
-
-            try {
-                await this.imageRepository.uploadAvoidedCollisionData(mowerID, mowSessionID, avoidedCollisionData);
-                resolve()
-            } catch(e) {
-                console.error("ERROR - Could not upload avoidedCollisionData for mowSessionID : " + mowSessionID)
-                reject(e)
-            }
-            
-        });
+        await this.imageRepository.uploadAvoidedCollisionData(mowerID, mowSessionID, avoidedCollisionData);
     }
-
-    //TODO: Add business-logic
 }

--- a/src/businessLogic/imageService.mjs
+++ b/src/businessLogic/imageService.mjs
@@ -2,9 +2,9 @@ import { ValidationError } from '../utils/errors.mjs';
 import { formatDate } from '../utils/dateFormatter.mjs';
 
 export default class ImageService {
-    constructor({ imageRepository, mowSessionRepository }) {
+    constructor({ imageRepository, mowerRepository }) {
         this.imageRepository = imageRepository;
-        this.mowSessionRepository = mowSessionRepository
+        this.mowerRepository = mowerRepository
 
     }
 

--- a/src/businessLogic/imageService.mjs
+++ b/src/businessLogic/imageService.mjs
@@ -1,4 +1,5 @@
 import { ValidationError } from '../utils/errors.mjs';
+import { formatDate } from '../utils/dateFormatter.mjs';
 
 export default class ImageService {
     constructor({ imageRepository }) {
@@ -8,19 +9,8 @@ export default class ImageService {
     uploadImageToStorage(mowerID, imageUInt8Array) {
         return new Promise(async (resolve, reject) => {
             const currentDate = new Date();
-
-            // Extract the individual components of the date and time
-            const year = currentDate.getFullYear();
-            const month = String(currentDate.getMonth() + 1).padStart(2, "0");
-            const day = String(currentDate.getDate()).padStart(2, "0");
-            const hours = String(currentDate.getHours()).padStart(2, "0");
-            const minutes = String(currentDate.getMinutes()).padStart(2, "0");
-            const seconds = String(currentDate.getSeconds()).padStart(2, "0");
-
-            // Format the date and time string
-            const formattedDateTime = `${year}-${month}-${day}_${hours}:${minutes}:${seconds}`;
+            const formattedDateTime = formatDate(currentDate)
             const imageFilename = `${mowerID}/${formattedDateTime}.jpg`;
-
             try {
                 const fileName =
                     await this.imageRepository.uploadImageToStorage(

--- a/src/businessLogic/mowSessionService.mjs
+++ b/src/businessLogic/mowSessionService.mjs
@@ -1,4 +1,5 @@
 import { ValidationError } from '../utils/errors.mjs';
+import { formatDate } from '../utils/dateFormatter.mjs';
 
 export default class MowSessionService{
     constructor({mowSessionRepository, mowerRepository}){
@@ -41,10 +42,10 @@ export default class MowSessionService{
         }
 
         const currentDate = new Date();
-        const formattedDate = currentDate.toISOString().slice(0, 10);
+        const formattedCurrentDate = formatDate(currentDate)
         const mowSessionData = {
             path: [],
-            start: formattedDate,
+            start: formattedCurrentDate,
             end: null
         }
         return await this.mowSessionRepository.startMowSessionByMowerId(mowerId, mowSessionData);
@@ -52,7 +53,7 @@ export default class MowSessionService{
 
     async endMowSessionByMowerId(mowerId) {
         const currentDate = new Date();
-        const formattedCurrentDate = currentDate.toISOString().slice(0, 10);
+        const formattedCurrentDate = formatDate(currentDate)
         
         const activeMowSession = await this.mowSessionRepository.getActiveMowSession(mowerId);
         const mowerExists = await this.mowerExists(mowerId)
@@ -82,5 +83,5 @@ export default class MowSessionService{
     
         // Update the mow session path in the repository
         await this.mowSessionRepository.updateMowSessionPath(mowerId, activeMowSession.id, newPath);
-    }
+    }      
 }

--- a/src/businessLogic/mowSessionService.mjs
+++ b/src/businessLogic/mowSessionService.mjs
@@ -1,3 +1,5 @@
+import { ValidationError, InternalServerError } from '../utils/errors.mjs';
+
 export default class MowSessionService{
     constructor({mowSessionRepository}){
         this.mowSessionRepository = mowSessionRepository

--- a/src/businessLogic/mowSessionService.mjs
+++ b/src/businessLogic/mowSessionService.mjs
@@ -6,16 +6,19 @@ export default class MowSessionService{
     async getAllMowSessionsByMowerId(mowerId){
         const mowSessions = await this.mowSessionRepository.getAllMowSessionsByMowerId(mowerId)
         return mowSessions
-
     }
 
     async getActiveMowSessionByMowerId(mowerId){
         const activeMowSession = await this.mowSessionRepository.getActiveMowSession(mowerId)
         return activeMowSession
-
     }
 
     async startMowSessionByMowerId(mowerId){
+        const activeMowSession = await this.mowSessionRepository.getActiveMowSession(mowerId)
+        if (activeMowSession) {
+            throw new Error('Cannot start a new mow session when an active session exists.');
+        }
+
         const currentDate = new Date();
         const formattedDate = currentDate.toISOString().slice(0, 10);
         const mowSessionData = {
@@ -34,8 +37,7 @@ export default class MowSessionService{
         const activeMowSession = await this.mowSessionRepository.getActiveMowSession(mowerId);
     
         if (!activeMowSession) {
-            console.log("No active mow session found.");
-            return;
+            throw new Error('Cannot end a mow session when there is no active session.');
         }
     
         // Update the end field of the active session with currentDate
@@ -47,8 +49,7 @@ export default class MowSessionService{
         const activeMowSession = await this.mowSessionRepository.getActiveMowSession(mowerId);
     
         if (!activeMowSession) {
-            console.log("No active mowing session found.");
-            return;
+            throw new Error('Cannot update path when there is no active session');
         }
         // Append currentPosition to the path
         const newPath = activeMowSession.path ? [...activeMowSession.path, currentPosition] : [currentPosition];

--- a/src/businessLogic/mowSessionService.mjs
+++ b/src/businessLogic/mowSessionService.mjs
@@ -3,14 +3,14 @@ export default class MowSessionService{
         this.mowSessionRepository = mowSessionRepository
     }
 
-    async getAllSessionsByMowerId(mowerId){
-        const mowSessions = await this.mowSessionRepository.getAllSessionsByMowerId(mowerId)
+    async getAllMowSessionsByMowerId(mowerId){
+        const mowSessions = await this.mowSessionRepository.getAllMowSessionsByMowerId(mowerId)
         return mowSessions
 
     }
 
-    async getActiveSessionByMowerId(mowerId){
-        const activeMowSession = await this.mowSessionRepository.getActiveSession(mowerId)
+    async getActiveMowSessionByMowerId(mowerId){
+        const activeMowSession = await this.mowSessionRepository.getActiveMowSession(mowerId)
         return activeMowSession
 
     }
@@ -18,12 +18,12 @@ export default class MowSessionService{
     async startMowSessionByMowerId(mowerId){
         const currentDate = new Date();
         const formattedDate = currentDate.toISOString().slice(0, 10);
-        const sessionData = {
+        const mowSessionData = {
             path: [],
             start: formattedDate,
             end: null
         }
-        return await this.mowSessionRepository.startMowSessionByMowerId(mowerId, sessionData);
+        return await this.mowSessionRepository.startMowSessionByMowerId(mowerId, mowSessionData);
     }
 
     async endMowSessionByMowerId(mowerId) {
@@ -31,10 +31,10 @@ export default class MowSessionService{
         const formattedCurrentDate = currentDate.toISOString().slice(0, 10);
         
         // Get the active mow-session
-        const activeMowSession = await this.mowSessionRepository.getActiveSession(mowerId);
+        const activeMowSession = await this.mowSessionRepository.getActiveMowSession(mowerId);
     
         if (!activeMowSession) {
-            console.log("No active mowing session found.");
+            console.log("No active mow session found.");
             return;
         }
     
@@ -44,7 +44,7 @@ export default class MowSessionService{
 
     async updateMowSessionPath(mowerId, currentPosition) {
         // Get the active mow-session
-        const activeMowSession = await this.mowSessionRepository.getActiveSession(mowerId);
+        const activeMowSession = await this.mowSessionRepository.getActiveMowSession(mowerId);
     
         if (!activeMowSession) {
             console.log("No active mowing session found.");

--- a/src/businessLogic/mowSessionService.mjs
+++ b/src/businessLogic/mowSessionService.mjs
@@ -18,7 +18,7 @@ export default class MowSessionService{
     async startMowSessionByMowerId(mowerId){
         const activeMowSession = await this.mowSessionRepository.getActiveMowSession(mowerId)
         if (activeMowSession) {
-            throw new Error('Cannot start a new mow session when an active session exists.');
+            throw new ValidationError('Cannot start a new mow session when an active session exists.');
         }
 
         const currentDate = new Date();
@@ -39,9 +39,8 @@ export default class MowSessionService{
         const activeMowSession = await this.mowSessionRepository.getActiveMowSession(mowerId);
     
         if (!activeMowSession) {
-            throw new Error('Cannot end a mow session when there is no active session.');
+            throw new ValidationError('Cannot end a mow session when there is no active session.');
         }
-    
         // Update the end field of the active session with currentDate
         await this.mowSessionRepository.endMowSession(mowerId, activeMowSession.id, formattedCurrentDate);
     }
@@ -51,7 +50,7 @@ export default class MowSessionService{
         const activeMowSession = await this.mowSessionRepository.getActiveMowSession(mowerId);
     
         if (!activeMowSession) {
-            throw new Error('Cannot update path when there is no active session');
+            throw new ValidationError('Cannot update path when there is no active session');
         }
         // Append currentPosition to the path
         const newPath = activeMowSession.path ? [...activeMowSession.path, currentPosition] : [currentPosition];

--- a/src/businessLogic/positionService.mjs
+++ b/src/businessLogic/positionService.mjs
@@ -1,9 +1,15 @@
 import { ValidationError } from '../utils/errors.mjs';
 
 export default class PositionService{
-    constructor({positionRepository, mowSessionService}){
+    constructor({positionRepository, mowerRepository, mowSessionService}){
         this.positionRepository = positionRepository
+        this.mowerRepository = mowerRepository
         this.mowSessionService = mowSessionService
+    }
+
+    async mowerExists(mowerId){
+        const mower = await this.mowerRepository.getMowerById(mowerId)
+        return mower == null ? false : true
     }
 
     async getCoordinates(mowerID) {
@@ -19,9 +25,14 @@ export default class PositionService{
     }
 
     async updatePosition(mowerId, position){
-        // Updates Mowing session path
-        await this.mowSessionService.updateMowSessionPath(mowerId, position)
-
-        // TODO: Update mower position
+        const mowerExists = await this.mowerExists(mowerId)
+        if(mowerExists){
+            // Updates Mowing session path
+            await this.mowSessionService.updateMowSessionPath(mowerId, position)
+            //Updates Mower position
+            await this.positionRepository.updateCoordinates(mowerId, position)
+        } else {
+            throw new ValidationError("The mower does not exist")
+        }
     }
 }

--- a/src/businessLogic/positionService.mjs
+++ b/src/businessLogic/positionService.mjs
@@ -1,4 +1,4 @@
-import { ValidationError, InternalServerError } from '../utils/errors.mjs';
+import { ValidationError } from '../utils/errors.mjs';
 
 export default class PositionService{
     constructor({positionRepository, mowSessionService}){

--- a/src/businessLogic/positionService.mjs
+++ b/src/businessLogic/positionService.mjs
@@ -1,3 +1,5 @@
+import { ValidationError, InternalServerError } from '../utils/errors.mjs';
+
 export default class PositionService{
     constructor({positionRepository, mowSessionService}){
         this.positionRepository = positionRepository

--- a/src/businessLogic/positionService.mjs
+++ b/src/businessLogic/positionService.mjs
@@ -12,16 +12,12 @@ export default class PositionService{
         return mower == null ? false : true
     }
 
-    async getCoordinates(mowerID) {
-        return new Promise(async (resolve, reject) => {
-            try {
-                const coordinates = this.positionRepository.getCoordinates(mowerID)
-                resolve(coordinates)
-            } catch (e) {
-                console.error("ERROR Service - Could not fetch coordinates for mower with id : " + mowerID)
-                reject(e)
-            }
-        })
+    async getCoordinates(mowerId) {
+        const mowerExists = await this.mowerExists(mowerId)
+        if(!mowerExists){
+            throw new ValidationError("The mower does not exist")
+        } 
+        return await this.positionRepository.getCoordinates(mowerId)
     }
 
     async updatePosition(mowerId, position){

--- a/src/container.mjs
+++ b/src/container.mjs
@@ -15,6 +15,8 @@ import imageRouter from './presentation/routers/imageRouter.mjs'
 import imageService from './businessLogic/imageService.mjs'
 import imageRepository from './dataAccess/imageRepository.mjs'
 
+import mowerRepository from './dataAccess/mowerRepository.mjs'
+
 const container = createContainer()
 
 
@@ -36,7 +38,8 @@ container.register({
     mowSessionRepository: asClass(mowSessionRepository),
 
     db: asValue(db),
-    imageAnnotatorClient: asValue(imageAnnotatorClient)
+    imageAnnotatorClient: asValue(imageAnnotatorClient),
+    mowerRepository: asClass(mowerRepository)
 })
 
 export default container;

--- a/src/dataAccess/imageRepository.mjs
+++ b/src/dataAccess/imageRepository.mjs
@@ -1,6 +1,6 @@
 import { getStorage, ref, uploadBytes } from "firebase/storage";
 import { addDoc, doc, getDoc, collection } from "firebase/firestore"; 
-import { ValidationError, InternalServerError } from '../utils/errors.mjs';
+import { ValidationError } from '../utils/errors.mjs';
 
 export default class ImageRepository {
     constructor({ db, imageAnnotatorClient }) {

--- a/src/dataAccess/imageRepository.mjs
+++ b/src/dataAccess/imageRepository.mjs
@@ -7,50 +7,27 @@ export default class ImageRepository {
         this.imageAnnotatorClient = imageAnnotatorClient
     }
 
-    uploadImageToStorage(imageFileName, uint8Array) {
-        return new Promise(async (resolve, reject) => {
-            const storage = getStorage();
-            const storageReference = ref(storage, imageFileName);
+    async uploadImageToStorage(imageFileName, uint8Array) {
+        const storage = getStorage();
+        const storageReference = ref(storage, imageFileName);
+        await uploadBytes(storageReference, uint8Array);
+        return imageFileName;
+    }
     
-            try {
-                await uploadBytes(storageReference, uint8Array);
-                resolve(imageFileName);
-            } catch (e) {
-                console.error("ERROR - Could not upload image to Storage...", e);
-                reject(e);
-            }
-        });
+    async classifyImage(request) {
+        const results = await this.imageAnnotatorClient.annotateImage(request);
+        return results[0].localizedObjectAnnotations;
     }
-
-    classifyImage(request) {
-        return new Promise(async (resolve, reject) => {
-            try {
-                const results = await this.imageAnnotatorClient.annotateImage(request);
-                resolve(results[0].localizedObjectAnnotations);
-            } catch (e) {
-                console.error("ERROR - Could not classify image...", e);
-                reject(e);
-            }
-        });
-    }
-
-    uploadAvoidedCollisionData(mowerID, mowSessionID, avoidedCollisionData) {
-        return new Promise(async (resolve, reject) => {
-            try {
-                // 2. Fetch mowSession document reference using mowerID & mowSessionID
-                const mowSessionDocRef = doc(this.db, `mowers/${mowerID}/mowSessions/${mowSessionID}`)
-
-                // // 3. Fetch Reference to avoidedCollisions collections
-                const avoidedCollisionRef = collection(mowSessionDocRef, "avoidedCollisions")
-
-                // 3. Add document to avoidedCollisions!
-                await addDoc(avoidedCollisionRef, avoidedCollisionData)
-                resolve()
-            } catch (e) {
-                console.error("ERROR - Could not upload collisionData to Firestore")
-                reject(e)
-            }
-        })
+    
+    async uploadAvoidedCollisionData(mowerID, mowSessionID, avoidedCollisionData) {
+        // 2. Fetch mowSession document reference using mowerID & mowSessionID
+        const mowSessionDocRef = doc(this.db, `mowers/${mowerID}/mowSessions/${mowSessionID}`)
+    
+        // // 3. Fetch Reference to avoidedCollisions collections
+        const avoidedCollisionRef = collection(mowSessionDocRef, "avoidedCollisions")
+    
+        // 3. Add document to avoidedCollisions!
+        await addDoc(avoidedCollisionRef, avoidedCollisionData);
     }
 
     //TODO: Add data-access functions

--- a/src/dataAccess/imageRepository.mjs
+++ b/src/dataAccess/imageRepository.mjs
@@ -1,6 +1,5 @@
 import { getStorage, ref, uploadBytes } from "firebase/storage";
 import { addDoc, doc, getDoc, collection } from "firebase/firestore"; 
-import { ValidationError } from '../utils/errors.mjs';
 
 export default class ImageRepository {
     constructor({ db, imageAnnotatorClient }) {

--- a/src/dataAccess/imageRepository.mjs
+++ b/src/dataAccess/imageRepository.mjs
@@ -1,5 +1,6 @@
 import { getStorage, ref, uploadBytes } from "firebase/storage";
 import { addDoc, doc, getDoc, collection } from "firebase/firestore"; 
+import { ValidationError, InternalServerError } from '../utils/errors.mjs';
 
 export default class ImageRepository {
     constructor({ db, imageAnnotatorClient }) {

--- a/src/dataAccess/mowSessionRepository.mjs
+++ b/src/dataAccess/mowSessionRepository.mjs
@@ -1,5 +1,5 @@
 import { collection, doc, getDoc, addDoc, getDocs, updateDoc, query, where } from 'firebase/firestore';
-import { ValidationError, InternalServerError } from '../utils/errors.mjs';
+import { ValidationError } from '../utils/errors.mjs';
 
 export default class MowSessionRepository {
     constructor({ db }) {

--- a/src/dataAccess/mowSessionRepository.mjs
+++ b/src/dataAccess/mowSessionRepository.mjs
@@ -1,5 +1,4 @@
 import { collection, doc, getDoc, addDoc, getDocs, updateDoc, query, where } from 'firebase/firestore';
-import { ValidationError } from '../utils/errors.mjs';
 
 export default class MowSessionRepository {
     constructor({ db }) {

--- a/src/dataAccess/mowSessionRepository.mjs
+++ b/src/dataAccess/mowSessionRepository.mjs
@@ -5,53 +5,53 @@ export default class MowSessionRepository {
         this.db = db;
     }
 
-    async getAllSessionsByMowerId(mowerId) {
-        const sessionsCollectionRef = collection(this.db, `mowers/${mowerId}/mowSessions`);
-        const sessionsSnapshot = await getDocs(sessionsCollectionRef);
-        const sessions = [];
+    async getAllMowSessionsByMowerId(mowerId) {
+        const mowSessionsCollectionRef = collection(this.db, `mowers/${mowerId}/mowSessions`);
+        const mowSessionsSnapshot = await getDocs(mowSessionsCollectionRef);
+        const mowSessions = [];
 
-        sessionsSnapshot.forEach((sessionDoc) => {
-            sessions.push({
-                id: sessionDoc.id,
-                ...sessionDoc.data(),
+        mowSessionsSnapshot.forEach((mowSessionDoc) => {
+            mowSessions.push({
+                id: mowSessionDoc.id,
+                ...mowSessionDoc.data(),
             });
         });
 
-        return sessions;
+        return mowSessions;
     }
 
-    async getActiveSession(mowerId) {
-        const sessionsCollectionRef = collection(this.db, `mowers/${mowerId}/mowSessions`);
-        const activeSessionQuery = query(sessionsCollectionRef, where('end', '==', null));
-        const activeSessionSnapshot = await getDocs(activeSessionQuery);
+    async getActiveMowSession(mowerId) {
+        const MowSessionsCollectionRef = collection(this.db, `mowers/${mowerId}/mowSessions`);
+        const activeMowSessionQuery = query(MowSessionsCollectionRef, where('end', '==', null));
+        const activeMowSessionSnapshot = await getDocs(activeMowSessionQuery);
     
-        if (activeSessionSnapshot.empty) {
+        if (activeMowSessionSnapshot.empty) {
             return null;
         }
     
         return {
-            id: activeSessionSnapshot.docs[0].id,
-            ...activeSessionSnapshot.docs[0].data(),
+            id: activeMowSessionSnapshot.docs[0].id,
+            ...activeMowSessionSnapshot.docs[0].data(),
         };
     }
 
-    async startMowSessionByMowerId(mowerId, sessionData) {
+    async startMowSessionByMowerId(mowerId, mowSessionData) {
         // Get the specified mower document by its ID
         const mowerRef = doc(this.db, `mowers/${mowerId}`);
 
         // Add a new document to the nested sessions collection
-        const sessionsCollection = collection(mowerRef, 'mowSessions');
-        const newSessionRef = await addDoc(sessionsCollection, sessionData);
-        return newSessionRef.id;
+        const mowSessionsCollection = collection(mowerRef, 'mowSessions');
+        const newMowSessionRef = await addDoc(mowSessionsCollection, mowSessionData);
+        return newMowSessionRef.id;
     }
 
-    async endMowSession(mowerId, sessionId, endDate) {
-        const sessionDocRef = doc(this.db, `mowers/${mowerId}/mowSessions/${sessionId}`);
-        await updateDoc(sessionDocRef, { end: endDate });
+    async endMowSession(mowerId, mowSessionId, endDate) {
+        const mowSessionDocRef = doc(this.db, `mowers/${mowerId}/mowSessions/${mowSessionId}`);
+        await updateDoc(mowSessionDocRef, { end: endDate });
     }
 
-    async updateMowSessionPath(mowerId, sessionId, newPath) {
-        const sessionDocRef = doc(this.db, `mowers/${mowerId}/mowSessions/${sessionId}`);
-        await updateDoc(sessionDocRef, { path: newPath });
+    async updateMowSessionPath(mowerId, mowSessionId, newPath) {
+        const mowSessionDocRef = doc(this.db, `mowers/${mowerId}/mowSessions/${mowSessionId}`);
+        await updateDoc(mowSessionDocRef, { path: newPath });
     }
 }

--- a/src/dataAccess/mowSessionRepository.mjs
+++ b/src/dataAccess/mowSessionRepository.mjs
@@ -1,4 +1,5 @@
 import { collection, doc, getDoc, addDoc, getDocs, updateDoc, query, where } from 'firebase/firestore';
+import { ValidationError, InternalServerError } from '../utils/errors.mjs';
 
 export default class MowSessionRepository {
     constructor({ db }) {

--- a/src/dataAccess/mowerRepository.mjs
+++ b/src/dataAccess/mowerRepository.mjs
@@ -1,0 +1,26 @@
+import { collection, doc, getDoc, addDoc, getDocs, updateDoc, query, where } from 'firebase/firestore';
+
+export default class MowerRepository {
+    constructor({ db }) {
+        this.db = db;
+    }
+
+    async getMowerById(mowerId){
+        try{
+            const mowerDocRef = doc(this.db, `mowers/${mowerId}`);
+            const mowerDocSnap = await getDoc(mowerDocRef);
+
+            if(mowerDocSnap.exists()){
+                return {
+                    id: mowerDocSnap.id,
+                    ...mowerDocSnap.data(),
+                }
+            } else {
+                return null
+            }
+        } catch (error) {
+            console.error(`ERROR Repository - Could not fetch mower with id ${mowerId}`);
+            throw new Error("Error fetching mower")
+        }
+    }
+}

--- a/src/dataAccess/mowerRepository.mjs
+++ b/src/dataAccess/mowerRepository.mjs
@@ -6,21 +6,16 @@ export default class MowerRepository {
     }
 
     async getMowerById(mowerId){
-        try{
-            const mowerDocRef = doc(this.db, `mowers/${mowerId}`);
-            const mowerDocSnap = await getDoc(mowerDocRef);
+        const mowerDocRef = doc(this.db, `mowers/${mowerId}`);
+        const mowerDocSnap = await getDoc(mowerDocRef);
 
-            if(mowerDocSnap.exists()){
-                return {
-                    id: mowerDocSnap.id,
-                    ...mowerDocSnap.data(),
-                }
-            } else {
-                return null
+        if(mowerDocSnap.exists()){
+            return {
+                id: mowerDocSnap.id,
+                ...mowerDocSnap.data(),
             }
-        } catch (error) {
-            console.error(`ERROR Repository - Could not fetch mower with id ${mowerId}`);
-            throw new Error("Error fetching mower")
+        } else {
+            return null
         }
     }
 }

--- a/src/dataAccess/positionRepository.mjs
+++ b/src/dataAccess/positionRepository.mjs
@@ -1,5 +1,4 @@
-import { getDoc, doc } from "firebase/firestore";
-import { ValidationError } from '../utils/errors.mjs';
+import { getDoc, doc, updateDoc } from "firebase/firestore";
 
 export default class PositionRepository{
     constructor({ db }){
@@ -17,8 +16,12 @@ export default class PositionRepository{
                 console.error("ERROR Repository - Could not fetch coordinates for mower with id " + mowerID)
                 reject(e) 
             }
-
-
         })
+    }
+
+
+    async updateCoordinates(mowerID, newPosition) {
+        const mowerDocRef = doc(this.db, `mowers/${mowerID}`)
+        await updateDoc(mowerDocRef, { position: newPosition });
     }
 }

--- a/src/dataAccess/positionRepository.mjs
+++ b/src/dataAccess/positionRepository.mjs
@@ -1,4 +1,5 @@
 import { getDoc, doc } from "firebase/firestore";
+import { ValidationError, InternalServerError } from '../utils/errors.mjs';
 
 export default class PositionRepository{
     constructor({ db }){

--- a/src/dataAccess/positionRepository.mjs
+++ b/src/dataAccess/positionRepository.mjs
@@ -5,20 +5,11 @@ export default class PositionRepository{
         this.db = db;
     }
 
-    //TODO: Add data-access functions
     async getCoordinates(mowerID) {
-        return new Promise(async (resolve, reject) => {
-            try {
-                const mowerDocRef = doc(this.db, `mowers/${mowerID}`)
-                const mowerDocSnap = await getDoc(mowerDocRef)
-                resolve(mowerDocSnap.data().position)
-            } catch (e) {
-                console.error("ERROR Repository - Could not fetch coordinates for mower with id " + mowerID)
-                reject(e) 
-            }
-        })
+        const mowerDocRef = doc(this.db, `mowers/${mowerID}`)
+        const mowerDocSnap = await getDoc(mowerDocRef)
+        return(mowerDocSnap.data().position)
     }
-
 
     async updateCoordinates(mowerID, newPosition) {
         const mowerDocRef = doc(this.db, `mowers/${mowerID}`)

--- a/src/dataAccess/positionRepository.mjs
+++ b/src/dataAccess/positionRepository.mjs
@@ -1,5 +1,5 @@
 import { getDoc, doc } from "firebase/firestore";
-import { ValidationError, InternalServerError } from '../utils/errors.mjs';
+import { ValidationError } from '../utils/errors.mjs';
 
 export default class PositionRepository{
     constructor({ db }){

--- a/src/presentation/app.mjs
+++ b/src/presentation/app.mjs
@@ -1,4 +1,5 @@
 import express from 'express'
+import errorHandler from '../utils/errorHandler.mjs';
 
 const expressApp = express()
 expressApp.use(express.json());
@@ -19,10 +20,13 @@ export default function ({
   expressApp.use("/image", imageRouter)
   expressApp.use("/mow-session", mowSessionRouter)
 
+  // Error handling middleware
+  expressApp.use(errorHandler);
+
   expressApp.get("/", (req, res) => {
     res.send("TIGN13")
   })
-  
+
   return expressApp
 }
 

--- a/src/presentation/routers/imageRouter.mjs
+++ b/src/presentation/routers/imageRouter.mjs
@@ -30,9 +30,13 @@ export default function createImageRouter({ imageService, positionService }) {
             await imageService.uploadAvoidedCollisionData(mowerID, mowSessionID, avoidedCollisionData)
 
             res.sendStatus(200);
-        } catch (e) {
-            console.error("ERROR - Collision avoidance image could not be uploaded...")
-            res.sendStatus(400);
+        } catch (error) {
+            console.error(error)
+            if (error instanceof ValidationError) {
+                res.status(400).json({ error: error.message });
+            } else {
+                res.status(500).json({ error: 'An internal server error occurred.' });
+            }
         }
     });
 

--- a/src/presentation/routers/imageRouter.mjs
+++ b/src/presentation/routers/imageRouter.mjs
@@ -1,6 +1,6 @@
 import express from "express";
 import bodyParser from "body-parser";
-import { ValidationError, InternalServerError } from '../../utils/errors.mjs';
+import { ValidationError } from '../../utils/errors.mjs';
 
 export default function createImageRouter({ imageService, positionService }) {
     const router = express.Router();

--- a/src/presentation/routers/imageRouter.mjs
+++ b/src/presentation/routers/imageRouter.mjs
@@ -1,5 +1,6 @@
 import express from "express";
 import bodyParser from "body-parser";
+import { ValidationError, InternalServerError } from '../../utils/errors.mjs';
 
 export default function createImageRouter({ imageService, positionService }) {
     const router = express.Router();

--- a/src/presentation/routers/imageRouter.mjs
+++ b/src/presentation/routers/imageRouter.mjs
@@ -31,12 +31,7 @@ export default function createImageRouter({ imageService, positionService }) {
 
             res.sendStatus(200);
         } catch (error) {
-            console.error(error)
-            if (error instanceof ValidationError) {
-                res.status(400).json({ error: error.message });
-            } else {
-                res.status(500).json({ error: 'An internal server error occurred.' });
-            }
+            next(error)
         }
     });
 

--- a/src/presentation/routers/imageRouter.mjs
+++ b/src/presentation/routers/imageRouter.mjs
@@ -1,6 +1,5 @@
 import express from "express";
 import bodyParser from "body-parser";
-import { ValidationError } from '../../utils/errors.mjs';
 
 export default function createImageRouter({ imageService, positionService }) {
     const router = express.Router();

--- a/src/presentation/routers/imageRouter.mjs
+++ b/src/presentation/routers/imageRouter.mjs
@@ -10,7 +10,7 @@ export default function createImageRouter({ imageService, positionService }) {
 
     // Upload image
     // Find out how IMAGE can be sent from Mower to API?
-    router.post("/upload/:mowerID/:mowSessionID", async (req, res) => {
+    router.post("/upload/:mowerID/:mowSessionID", async (req, res, next) => {
         const uint8Array = new Uint8Array(req.body);
         const mowerID = req.params.mowerID;
         const mowSessionID = req.params.mowSessionID;

--- a/src/presentation/routers/mowSessionRouter.mjs
+++ b/src/presentation/routers/mowSessionRouter.mjs
@@ -14,7 +14,11 @@ export default function createMowSessionRouter({mowSessionService}) {
             res.status(200).json(mowSessions)
         } catch (error) {
             console.error(error)
-            res.status(500).json({ error: error.message })
+            if(error instanceof ValidationError){
+                res.status(400).json({error: error.message})
+            } else {
+                res.status(500).json({error: error.message})
+            }
         }
     });
 
@@ -26,7 +30,11 @@ export default function createMowSessionRouter({mowSessionService}) {
             res.status(200).json(activeMowSession)
         } catch (error) {
             console.error(error)
-            res.status(500).json({ error: error.message })
+            if (error instanceof ValidationError) {
+                res.status(400).json({ error: error.message });
+            } else {
+                res.status(500).json({ error: 'An internal server error occurred.' });
+            }
         }
     });
 
@@ -37,7 +45,11 @@ export default function createMowSessionRouter({mowSessionService}) {
             res.status(201).json({ message: 'Mowing session started successfully', mowSessionId });
         } catch (error) {
             console.error(error)
-            res.status(500).json({ error: error.message });
+            if (error instanceof ValidationError) {
+                res.status(400).json({ error: error.message });
+            } else {
+                res.status(500).json({ error: 'An internal server error occurred.' });
+            }
         }
     });
 
@@ -48,7 +60,11 @@ export default function createMowSessionRouter({mowSessionService}) {
             res.status(200).json({ message: 'Mowing session ended successfully' });
         } catch (error) {
             console.error(error)
-            res.status(500).json({ error: error.message })
+            if (error instanceof ValidationError) {
+                res.status(400).json({ error: error.message });
+            } else {
+                res.status(500).json({ error: 'An internal server error occurred.' });
+            }
         }
     });
     return router

--- a/src/presentation/routers/mowSessionRouter.mjs
+++ b/src/presentation/routers/mowSessionRouter.mjs
@@ -1,4 +1,5 @@
 import express from "express"
+import { ValidationError, InternalServerError } from '../../utils/errors.mjs';
 
 export default function createMowSessionRouter({mowSessionService}) {
 

--- a/src/presentation/routers/mowSessionRouter.mjs
+++ b/src/presentation/routers/mowSessionRouter.mjs
@@ -9,9 +9,10 @@ export default function createMowSessionRouter({mowSessionService}) {
     router.get("/mower/:id", async (req, res) => {
         const mowerId = req.params.id 
         try {
-            const sessions = await mowSessionService.getAllSessionsByMowerId(mowerId)
-            res.status(200).json(sessions)
+            const mowSessions = await mowSessionService.getAllMowSessionsByMowerId(mowerId)
+            res.status(200).json(mowSessions)
         } catch (error) {
+            console.error(error)
             res.status(500).json({ error: 'Internal server error' })
         }
     });
@@ -20,9 +21,10 @@ export default function createMowSessionRouter({mowSessionService}) {
     router.get("/mower/:id/active", async (req, res) => {
         const mowerId = req.params.id 
         try {
-            const activeSession = await mowSessionService.getActiveSessionByMowerId(mowerId)
-            res.status(200).json(activeSession)
+            const activeMowSession = await mowSessionService.getActiveMowSessionByMowerId(mowerId)
+            res.status(200).json(activeMowSession)
         } catch (error) {
+            console.error(error)
             res.status(500).json({ error: 'Internal server error' })
         }
     });
@@ -30,9 +32,10 @@ export default function createMowSessionRouter({mowSessionService}) {
     router.post("/start-session/:id", async (req, res) => {
         const mowerId = req.params.id;
         try {
-            const sessionId = await mowSessionService.startMowSessionByMowerId(mowerId);
-            res.status(201).json({ message: 'Mowing session started successfully', sessionId });
+            const mowSessionId = await mowSessionService.startMowSessionByMowerId(mowerId);
+            res.status(201).json({ message: 'Mowing session started successfully', mowSessionId });
         } catch (error) {
+            console.error(error)
             res.status(500).json({ error: 'Internal server error' });
         }
     });
@@ -43,9 +46,9 @@ export default function createMowSessionRouter({mowSessionService}) {
             await mowSessionService.endMowSessionByMowerId(mowerId)
             res.status(200).json({ message: 'Mowing session ended successfully' });
         } catch (error) {
+            console.error(error)
             res.status(500).json({ error: 'Internal server error' })
         }
     });
-
     return router
 }

--- a/src/presentation/routers/mowSessionRouter.mjs
+++ b/src/presentation/routers/mowSessionRouter.mjs
@@ -1,5 +1,4 @@
 import express from "express"
-import { ValidationError } from '../../utils/errors.mjs';
 
 export default function createMowSessionRouter({mowSessionService}) {
 

--- a/src/presentation/routers/mowSessionRouter.mjs
+++ b/src/presentation/routers/mowSessionRouter.mjs
@@ -1,5 +1,5 @@
 import express from "express"
-import { ValidationError, InternalServerError } from '../../utils/errors.mjs';
+import { ValidationError } from '../../utils/errors.mjs';
 
 export default function createMowSessionRouter({mowSessionService}) {
 
@@ -17,7 +17,7 @@ export default function createMowSessionRouter({mowSessionService}) {
             if(error instanceof ValidationError){
                 res.status(400).json({error: error.message})
             } else {
-                res.status(500).json({error: error.message})
+                res.status(500).json({error: 'An internal server error occurred.'})
             }
         }
     });

--- a/src/presentation/routers/mowSessionRouter.mjs
+++ b/src/presentation/routers/mowSessionRouter.mjs
@@ -13,7 +13,7 @@ export default function createMowSessionRouter({mowSessionService}) {
             res.status(200).json(mowSessions)
         } catch (error) {
             console.error(error)
-            res.status(500).json({ error: 'Internal server error' })
+            res.status(500).json({ error: error.message })
         }
     });
 
@@ -25,7 +25,7 @@ export default function createMowSessionRouter({mowSessionService}) {
             res.status(200).json(activeMowSession)
         } catch (error) {
             console.error(error)
-            res.status(500).json({ error: 'Internal server error' })
+            res.status(500).json({ error: error.message })
         }
     });
 
@@ -36,7 +36,7 @@ export default function createMowSessionRouter({mowSessionService}) {
             res.status(201).json({ message: 'Mowing session started successfully', mowSessionId });
         } catch (error) {
             console.error(error)
-            res.status(500).json({ error: 'Internal server error' });
+            res.status(500).json({ error: error.message });
         }
     });
 
@@ -47,7 +47,7 @@ export default function createMowSessionRouter({mowSessionService}) {
             res.status(200).json({ message: 'Mowing session ended successfully' });
         } catch (error) {
             console.error(error)
-            res.status(500).json({ error: 'Internal server error' })
+            res.status(500).json({ error: error.message })
         }
     });
     return router

--- a/src/presentation/routers/mowSessionRouter.mjs
+++ b/src/presentation/routers/mowSessionRouter.mjs
@@ -7,64 +7,44 @@ export default function createMowSessionRouter({mowSessionService}) {
 
 
     // Get all mow sessions for mower by mower-id
-    router.get("/mower/:id", async (req, res) => {
+    router.get("/mower/:id", async (req, res, next) => {
         const mowerId = req.params.id 
         try {
             const mowSessions = await mowSessionService.getAllMowSessionsByMowerId(mowerId)
             res.status(200).json(mowSessions)
         } catch (error) {
-            console.error(error)
-            if(error instanceof ValidationError){
-                res.status(400).json({error: error.message})
-            } else {
-                res.status(500).json({error: 'An internal server error occurred.'})
-            }
+            next(error)
         }
     });
 
     // Get active mow session by mower-id
-    router.get("/mower/:id/active", async (req, res) => {
+    router.get("/mower/:id/active", async (req, res, next) => {
         const mowerId = req.params.id 
         try {
             const activeMowSession = await mowSessionService.getActiveMowSessionByMowerId(mowerId)
             res.status(200).json(activeMowSession)
         } catch (error) {
-            console.error(error)
-            if (error instanceof ValidationError) {
-                res.status(400).json({ error: error.message });
-            } else {
-                res.status(500).json({ error: 'An internal server error occurred.' });
-            }
+            next(error)
         }
     });
 
-    router.post("/start-session/:id", async (req, res) => {
+    router.post("/start-session/:id", async (req, res, next) => {
         const mowerId = req.params.id;
         try {
             const mowSessionId = await mowSessionService.startMowSessionByMowerId(mowerId);
             res.status(201).json({ message: 'Mowing session started successfully', mowSessionId });
         } catch (error) {
-            console.error(error)
-            if (error instanceof ValidationError) {
-                res.status(400).json({ error: error.message });
-            } else {
-                res.status(500).json({ error: 'An internal server error occurred.' });
-            }
+            next(error)
         }
     });
 
-    router.post("/end-session/:id", async (req, res) => {
+    router.post("/end-session/:id", async (req, res, next) => {
         const mowerId = req.params.id
         try {
             await mowSessionService.endMowSessionByMowerId(mowerId)
             res.status(200).json({ message: 'Mowing session ended successfully' });
         } catch (error) {
-            console.error(error)
-            if (error instanceof ValidationError) {
-                res.status(400).json({ error: error.message });
-            } else {
-                res.status(500).json({ error: 'An internal server error occurred.' });
-            }
+            next(error)
         }
     });
     return router

--- a/src/presentation/routers/positionRouter.mjs
+++ b/src/presentation/routers/positionRouter.mjs
@@ -9,9 +9,17 @@ export default function createPositionRouter({positionService}) {
     // Get current position for 
     router.get("/:mowerID", async (req, res) => {
         const mowerID = req.params.mowerID
-        console.log(`Someone tried to GET position mowerID : ${mowerID}`);
-        const coordinates = await positionService.getCoordinates(mowerID)
-        res.json(coordinates)
+        try{
+            const coordinates = await positionService.getCoordinates(mowerID)
+            res.json(coordinates)
+        } catch (error){
+            console.error(error)
+            if (error instanceof ValidationError) {
+                res.status(400).json({ error: error.message });
+            } else {
+                res.status(500).json({ error: 'An internal server error occurred.' });
+            }
+        }
     })
 
     // Update position
@@ -22,7 +30,12 @@ export default function createPositionRouter({positionService}) {
             await positionService.updatePosition(mowerId, currentPostition)
             res.status(200).json({ message: "Position updated & added to the mowing session path" });
         } catch (error) {
-            res.status(500).json({ error: error.message });
+            console.error(error)
+            if (error instanceof ValidationError) {
+                res.status(400).json({ error: error.message });
+            } else {
+                res.status(500).json({ error: 'An internal server error occurred.' });
+            }
         }
     })
 

--- a/src/presentation/routers/positionRouter.mjs
+++ b/src/presentation/routers/positionRouter.mjs
@@ -1,5 +1,5 @@
 import express from "express"
-import { ValidationError, InternalServerError } from '../../utils/errors.mjs';
+import { ValidationError } from '../../utils/errors.mjs';
 
 export default function createPositionRouter({positionService}) {
 

--- a/src/presentation/routers/positionRouter.mjs
+++ b/src/presentation/routers/positionRouter.mjs
@@ -1,5 +1,4 @@
 import express from "express"
-import { ValidationError } from '../../utils/errors.mjs';
 
 export default function createPositionRouter({positionService}) {
 
@@ -11,7 +10,7 @@ export default function createPositionRouter({positionService}) {
         const mowerID = req.params.mowerID
         try{
             const coordinates = await positionService.getCoordinates(mowerID)
-            res.json(coordinates)
+            res.status(200).json(coordinates)
         } catch (error) {
             next(error)
         }

--- a/src/presentation/routers/positionRouter.mjs
+++ b/src/presentation/routers/positionRouter.mjs
@@ -21,7 +21,7 @@ export default function createPositionRouter({positionService}) {
             await positionService.updatePosition(mowerId, currentPostition)
             res.status(200).json({ message: "Position updated & added to the mowing session path" });
         } catch (error) {
-            res.status(500).json({ error: "Internal server error" });
+            res.status(500).json({ error: error.message });
         }
     })
 

--- a/src/presentation/routers/positionRouter.mjs
+++ b/src/presentation/routers/positionRouter.mjs
@@ -1,4 +1,5 @@
 import express from "express"
+import { ValidationError, InternalServerError } from '../../utils/errors.mjs';
 
 export default function createPositionRouter({positionService}) {
 

--- a/src/presentation/routers/positionRouter.mjs
+++ b/src/presentation/routers/positionRouter.mjs
@@ -7,35 +7,25 @@ export default function createPositionRouter({positionService}) {
     // What is the data format for position? 
 
     // Get current position for 
-    router.get("/:mowerID", async (req, res) => {
+    router.get("/:mowerID", async (req, res, next) => {
         const mowerID = req.params.mowerID
         try{
             const coordinates = await positionService.getCoordinates(mowerID)
             res.json(coordinates)
-        } catch (error){
-            console.error(error)
-            if (error instanceof ValidationError) {
-                res.status(400).json({ error: error.message });
-            } else {
-                res.status(500).json({ error: 'An internal server error occurred.' });
-            }
+        } catch (error) {
+            next(error)
         }
     })
 
     // Update position
-    router.post("/update/:id", async(req, res) => {
+    router.post("/update/:id", async(req, res, next) => {
         const mowerId = req.params.id
         const currentPostition = req.body.position 
         try {
             await positionService.updatePosition(mowerId, currentPostition)
             res.status(200).json({ message: "Position updated & added to the mowing session path" });
         } catch (error) {
-            console.error(error)
-            if (error instanceof ValidationError) {
-                res.status(400).json({ error: error.message });
-            } else {
-                res.status(500).json({ error: 'An internal server error occurred.' });
-            }
+            next(error)
         }
     })
 

--- a/src/utils/dateFormatter.mjs
+++ b/src/utils/dateFormatter.mjs
@@ -1,0 +1,12 @@
+export function formatDate(date) {
+    // Extract the individual components of the date and time
+    const year = date.getFullYear()
+    const month = String(date.getMonth() + 1).padStart(2, "0")
+    const day = String(date.getDate()).padStart(2, "0")
+    const hours = String(date.getHours()).padStart(2, "0")
+    const minutes = String(date.getMinutes()).padStart(2, "0")
+    const seconds = String(date.getSeconds()).padStart(2, "0")
+
+    // Format the date and time string
+    return `${year}-${month}-${day}_${hours}:${minutes}:${seconds}`
+}

--- a/src/utils/errorHandler.mjs
+++ b/src/utils/errorHandler.mjs
@@ -1,0 +1,12 @@
+import { ValidationError } from "./errors.mjs";
+function errorHandler(err, req, res, next) {
+    console.error(err);
+
+    if (err instanceof ValidationError) {
+        res.status(400).json({ error: err.message });
+    } else {
+        res.status(500).json({ error: "An internal server error occurred." });
+    }
+}
+
+export default errorHandler;

--- a/src/utils/errorHandler.mjs
+++ b/src/utils/errorHandler.mjs
@@ -1,7 +1,6 @@
 import { ValidationError } from "./errors.mjs";
 function errorHandler(err, req, res, next) {
     console.error(err);
-
     if (err instanceof ValidationError) {
         res.status(400).json({ error: err.message });
     } else {

--- a/src/utils/errors.mjs
+++ b/src/utils/errors.mjs
@@ -1,0 +1,13 @@
+export class ValidationError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = "ValidationError";
+    }
+}
+
+export class InternalServerError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = "InternalServerError";
+    }
+}

--- a/src/utils/errors.mjs
+++ b/src/utils/errors.mjs
@@ -4,10 +4,3 @@ export class ValidationError extends Error {
         this.name = "ValidationError";
     }
 }
-
-export class InternalServerError extends Error {
-    constructor(message) {
-        super(message);
-        this.name = "InternalServerError";
-    }
-}


### PR DESCRIPTION
Delegated error handling to presentation layer. Routers now are the sole users of try-catch blocks. 
When errors are caught, an "errorhandling" middleware takes care of the response.
Errors can be of status code 400 or 500. 
400 is sent for validation errors which also gives a descriptive message on the error.
500 is sent on every other error which gives the message "internal server error".
All errors are also logged in the console.

All service and repo functions now use the same async await structure. 

A mowerRepository was created for validation purposes (To check wether a mower exists or not for example)

A "utils" folder was created to adhere to DRY principle. This contains a custom error class, the errorhandling middleware & a dateformatter.